### PR TITLE
Fixes security issue with upload file name

### DIFF
--- a/photobackup_bottle/photobackup.py
+++ b/photobackup_bottle/photobackup.py
@@ -114,7 +114,7 @@ def validate_password(request, isTest=False):
 
 def save_file(upfile, filesize):
     """ Saves the sent file locally. """
-    path = os.path.join(config['MediaRoot'], upfile.raw_filename)
+    path = os.path.join(config['MediaRoot'], os.path.basename(upfile.raw_filename))
     if not os.path.exists(path):
 
         # save file


### PR DESCRIPTION
When the filename starts with '/', os.path.join ignores config['MediaRoot'] and just returns the raw_filename sent by the client. So if the client is compromised or malicious, it can write to any file in the server that can be written by the webserver process. E.g. below curl command will silently update .zshenv file

`curl --form "upfile=@hacker-env-file;filename=/home/balkierode/.zshenv" --form filesize=123 --form password=xxxxxxxxxxxx http://x.x.x.x:8420`

ref: https://docs.python.org/3/library/os.path.html#os.path.join

> If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component.