### PR TITLE
photobackup-bottle doesn't work with python3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Python3 implementation of PhotoBackup server, made with
 
 You need:
 
-- [Python3](https://www.python.org/) ;
+- [Python3.5 or higher](https://www.python.org/) ;
 - [pip](https://pip.pypa.io/en/stable/) ;
 - libffi-dev (installable though `[apt|yum] install libffi-dev`)
 


### PR DESCRIPTION
photobackup/server-bottle doesn't work with python3.4 but requires python3.5 because how file uploads
are expected to be parsed and how they are actually parsed (within cgi.py shipped with python3) differ.
python3.4 is still the default python version on jessie debian (Which is still in wide use). It should therefore be noted that python3.4 is not supported.

I tried to debug the photobackup/bottle/cgi.py code to find a specific reason why the picture upload did not work when running with python3.4, but couldn't produce any conclusive results in the time available. However i am very confident, that cgi.py as shipped with python3.4 interprets file uploads in unexpected ways (either bottle 0.12 expects something different, or photobackup v0.1.2 expects something different).
Using python3.5 with the same version of bottle and same version of photobackup works.